### PR TITLE
Update MySql.php table creation to utf8mb4

### DIFF
--- a/src/Drivers/MySql.php
+++ b/src/Drivers/MySql.php
@@ -36,7 +36,7 @@ class MySql extends SetGet implements SessionHandlerInterface
               `data` text NOT NULL,
               `time` int(11) unsigned NOT NULL,
               PRIMARY KEY (`id`)
-            ) ENGINE=InnoDB DEFAULT CHARSET=latin1;');
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;');
         }
     }
 


### PR DESCRIPTION
latin1 has really weird issues with utf8 characters. This should correct that.